### PR TITLE
hotfix/0.2.4

### DIFF
--- a/attachment.php
+++ b/attachment.php
@@ -10,7 +10,7 @@ if(empty($_SESSION['email'])){
     display_404();
 }
 
-$attachment_id = $_REQUEST['uuid'];
+$attachment_id = empty($_REQUEST['uuid']) ? '' : $_REQUEST['uuid'];
 if(!ProcessData::is_valid_uuid($attachment_id)){
     display_404();
 }

--- a/css/attachment.php
+++ b/css/attachment.php
@@ -10,7 +10,7 @@ if(empty($_SESSION['email'])){
 
 require_once __DIR__.'/../includes/ProcessData.php';
 
-$attachment_id = $_REQUEST['uuid'];
+$attachment_id = empty($_REQUEST['uuid']) ? '' : $_REQUEST['uuid'];
 if(!ProcessData::is_valid_uuid($attachment_id)){
     display_404();
 }


### PR DESCRIPTION
Added error handling in case attachment `uuid` value is not successfully passed when displaying attachments.